### PR TITLE
Update to OmniXAI 1.3.2 for Colab

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN echo "deb http://deb.debian.org/debian testing main contrib non-free" >> /et
 RUN apt-get update -y
 RUN apt-get install -y build-essential
 RUN apt-get install -y -t testing gcc-11
+RUN apt-get install -y git
 
 # Make sure the contents of our repo is in $HOME
 COPY requirements.txt $HOME/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-omnixai==1.3.2
+omnixai @ git+https://github.com/salesforce/OmniXAI.git@v1.3.2
 opencv-python==4.9.0.80
 pandas==2.0.3
 plotly==5.20.0


### PR DESCRIPTION
- **Use direct URL link to OmniXAI**
- **Add git in initial docker layer**

As OmniXAI cannot publish new version on Pypi for the time being
uset he direct URL to the git repo/tag as to make use of the lastest
version that include a needed fix for running OmniXAI on Google Colab.
